### PR TITLE
docs: synchronize documentation with current implementation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,17 +4,7 @@ Admin UI for the rag-suite stack. Single-pane management for all services — co
 
 ## Status
 
-**Scaffold — under active development.**
-
-Currently implemented:
-- `/health` — returns `{"status": "ok"}`
-
-Planned (not yet implemented):
-- Collections browser — Qdrant collection management
-- Ingest monitor — ragstuffer job status and manual trigger
-- Query log viewer — ragpipe query_log search and filter
-- Probe runs dashboard — ragprobe test results
-- Metrics dashboard — ragwatch/Prometheus integration
+**Production — fully implemented.** FastAPI backend with multiple endpoints, vanilla HTML/JS/CSS frontend with multiple pages, container image published to GHCR.
 
 ## Architecture
 ```
@@ -31,26 +21,68 @@ Planned (not yet implemented):
    └─────────┘ └────────┘ └───────┘ └─────────┘
 ```
 
+## Backend endpoints
+
+All endpoints require `RAGDECK_ADMIN_TOKEN` bearer authentication unless noted.
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| `GET` | `/health` | No | Returns `{"status": "ok"}` |
+| `GET` | `/admin/config` | Yes | ragpipe routing and prompt config |
+| `GET` | `/collections` | Yes | List all Qdrant collections with stats |
+| `GET` | `/collections/{name}` | Yes | Get specific collection details |
+| `GET` | `/ingest/status` | Yes | ragstuffer ingest job status |
+| `GET` | `/querylog` | Yes | Search ragpipe query log |
+| `GET` | `/querylog/{query_hash}` | Yes | Get specific query log entry |
+| `GET` | `/metrics` | Yes | Prometheus metrics from ragwatch |
+
+## Frontend pages
+
+| Route | Description |
+|-------|-------------|
+| `/` | Dashboard overview |
+| `/collections` | Qdrant collection browser |
+| `/ingest` | Ingest job monitor |
+| `/querylog` | Query log viewer with search |
+| `/metrics` | Real-time metrics dashboard |
+
 ## Package structure
 ```
 ragdeck/
   __init__.py      — empty (package marker)
-  main.py          — FastAPI app (health endpoint only currently)
+  main.py          — FastAPI app with all endpoints and page routes
+  static/
+    app.js         — frontend JavaScript
+    style.css      — frontend styles
+  templates/
+    base.html      — base template
+    admin.html     — admin config page
+    collections.html — collection browser
+    dashboard.html — overview dashboard
+    ingest.html    — ingest monitor
+    metrics.html   — metrics dashboard
+    querylog.html  — query log viewer
 tests/
-  test_main.py     — stub test for /health
+  test_auth.py     — authentication tests
+  test_collections.py — collection endpoint tests
+  test_health.py   — health endpoint tests
+  test_metrics.py  — metrics endpoint tests
+  test_querylog.py — query log endpoint tests
+  test_service_unavailable.py — error handling tests
 quadlets/
-  ragdeck.container — admin UI service quadlet (stub)
+  ragdeck.container — admin UI service quadlet
 ```
 
 ## Key design decisions
 - FastAPI backend for async API calls to all rag-suite services
 - Single-pane admin UI — one endpoint to manage the entire stack
 - No GPU required — pure API orchestration and UI rendering
-- Port 8095 (configured in main.py, not 8092)
+- Port 8092 (configured in main.py)
+- Authentication via `RAGDECK_ADMIN_TOKEN` bearer token
 
 ## Running tests
 ```bash
 pip install '.[dev]'
-python -m pytest tests/ -v
+python -m pytest tests/ -v    # 24 tests
 ruff check && ruff format --check
 ```

--- a/README.md
+++ b/README.md
@@ -6,10 +6,9 @@ Admin UI for the rag-suite stack. Single-pane management for all services — co
 
 ragdeck is the administrative control plane for the rag-suite. It provides a unified interface to:
 
-- **Collections** — browse, create, and manage Qdrant collections across all routes
-- **Ingest** — monitor ragstuffer job status, trigger manual ingestion, view processing queues
+- **Collections** — browse Qdrant collections across all routes, view collection stats
+- **Ingest** — monitor ragstuffer job status, view processing queues
 - **Query log** — search and filter the ragpipe query log, inspect grounding decisions and citations
-- **Probe runs** — view ragprobe test results, track grounding quality over time, detect regressions
 - **Metrics** — real-time dashboards powered by ragwatch (Prometheus + Grafana)
 
 ## How it fits into rag-suite
@@ -32,6 +31,23 @@ ragdeck is the administrative control plane for the rag-suite. It provides a uni
                                 └─────────┘
 ```
 
+## Quick start (container)
+
+```bash
+# Pull the published image
+podman pull ghcr.io/aclater/ragdeck:main
+
+# Run with admin token
+podman run --rm -p 8092:8092 \
+    -e RAGDECK_ADMIN_TOKEN=your-secure-token \
+    -e RAGPIPE_URL=http://localhost:8090 \
+    -e RAGPIPE_ADMIN_TOKEN=ragpipe-admin-token \
+    -e RAGSTUFFER_URL=http://localhost:8091 \
+    -e RAGSTUFFER_MPEP_URL=http://localhost:8093 \
+    -e QDRANT_URL=http://localhost:6333 \
+    ghcr.io/aclater/ragdeck:main
+```
+
 ## Quick start (pip)
 
 ```bash
@@ -48,44 +64,77 @@ pip install '.[dev]'
 python -m pytest tests/ -v
 ```
 
-## Running tests
+## Backend API
 
-```bash
-pip install '.[dev]'
-python -m pytest tests/ -v
-ruff check && ruff format --check
-```
+All endpoints require `RAGDECK_ADMIN_TOKEN` bearer authentication unless noted.
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| `GET` | `/health` | No | Returns `{"status": "ok"}` |
+| `GET` | `/admin/config` | Yes | Returns ragpipe routing and prompt configuration |
+| `GET` | `/collections` | Yes | List all Qdrant collections with stats |
+| `GET` | `/collections/{name}` | Yes | Get specific collection details |
+| `GET` | `/ingest/status` | Yes | ragstuffer ingest job status |
+| `GET` | `/querylog` | Yes | Search ragpipe query log |
+| `GET` | `/querylog/{query_hash}` | Yes | Get specific query log entry |
+| `GET` | `/metrics` | Yes | Prometheus metrics from ragwatch |
+
+## Frontend pages
+
+| Route | Description |
+|-------|-------------|
+| `/` | Dashboard overview |
+| `/collections` | Qdrant collection browser |
+| `/ingest` | Ingest job monitor |
+| `/querylog` | Query log viewer with search |
+| `/metrics` | Real-time metrics dashboard |
 
 ## Configuration
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `PORT` | `8095` | Port to listen on |
+| `PORT` | `8092` | Port to listen on |
+| `RAGDECK_ADMIN_TOKEN` | *(required)* | Bearer token for admin authentication |
+| `RAGPIPE_URL` | `http://localhost:8090` | ragpipe API URL |
+| `RAGPIPE_ADMIN_TOKEN` | *(required)* | Token for ragpipe admin endpoints |
+| `RAGSTUFFER_URL` | `http://localhost:8091` | ragstuffer API URL |
+| `RAGSTUFFER_MPEP_URL` | `http://localhost:8093` | ragstuffer-mpep API URL |
+| `QDRANT_URL` | `http://localhost:6333` | Qdrant API URL |
 
-## Status
+## Running tests
 
-**Under active development — scaffold.** Currently implemented:
-
-- `/health` — returns `{"status": "ok"}`
-
-Planned (not yet implemented):
-
-- Collections browser — Qdrant collection management
-- Ingest monitor — ragstuffer job status and manual trigger
-- Query log viewer — ragpipe query_log search and filter
-- Probe runs dashboard — ragprobe test results
-- Metrics dashboard — ragwatch/Prometheus integration
+```bash
+pip install '.[dev]'
+python -m pytest tests/ -v    # 24 tests
+ruff check && ruff format --check
+```
 
 ## Project structure
 
 ```
 ragdeck/
   __init__.py      — empty (package marker)
-  main.py          — FastAPI app (health endpoint only, currently)
+  main.py          — FastAPI app with all endpoints and page routes
+  static/
+    app.js         — frontend JavaScript
+    style.css      — frontend styles
+  templates/
+    base.html      — base template
+    admin.html     — admin config page
+    collections.html — collection browser
+    dashboard.html — overview dashboard
+    ingest.html    — ingest monitor
+    metrics.html   — metrics dashboard
+    querylog.html  — query log viewer
 tests/
-  test_main.py     — stub test for /health
+  test_auth.py     — authentication tests
+  test_collections.py — collection endpoint tests
+  test_health.py   — health endpoint tests
+  test_metrics.py  — metrics endpoint tests
+  test_querylog.py — query log endpoint tests
+  test_service_unavailable.py — error handling tests
 quadlets/
-  ragdeck.container — admin UI service quadlet (stub)
+  ragdeck.container — Podman quadlet for systemd integration
 ```
 
 ## License


### PR DESCRIPTION
Documentation update — ragdeck is fully implemented, not scaffold.

Key changes:
- Status updated from 'Scaffold' to 'Production'
- Port corrected: 8092 (not 8095)
- All backend endpoints documented (/admin/config, /collections, /ingest/status, /querylog, /metrics)
- All frontend pages documented (dashboard, collections, ingest, querylog, metrics)
- RAGDECK_ADMIN_TOKEN authentication documented
- Test count: 24 tests
- CLAUDE.md fully updated with implementation details

Closes #11 (container image published)