### PR TITLE
fix(ui): correct TemplateResponse signature in all UI page endpoints (fixes #22)

### DIFF
--- a/ragdeck/main.py
+++ b/ragdeck/main.py
@@ -804,29 +804,29 @@ async def admin_config():
 
 @app.get("/")
 async def dashboard(request: Request):
-    return templates.TemplateResponse("dashboard.html", {"request": request})
+    return templates.TemplateResponse(request, "dashboard.html", {"request": request})
 
 
 @app.get("/collections-ui")
 async def collections_page(request: Request):
-    return templates.TemplateResponse("collections.html", {"request": request})
+    return templates.TemplateResponse(request, "collections.html", {"request": request})
 
 
 @app.get("/querylog-ui")
 async def querylog_page(request: Request):
-    return templates.TemplateResponse("querylog.html", {"request": request})
+    return templates.TemplateResponse(request, "querylog.html", {"request": request})
 
 
 @app.get("/ingest-ui")
 async def ingest_page(request: Request):
-    return templates.TemplateResponse("ingest.html", {"request": request})
+    return templates.TemplateResponse(request, "ingest.html", {"request": request})
 
 
 @app.get("/metrics-ui")
 async def metrics_page(request: Request):
-    return templates.TemplateResponse("metrics.html", {"request": request})
+    return templates.TemplateResponse(request, "metrics.html", {"request": request})
 
 
 @app.get("/admin-ui")
 async def admin_page(request: Request):
-    return templates.TemplateResponse("admin.html", {"request": request})
+    return templates.TemplateResponse(request, "admin.html", {"request": request})

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -1,0 +1,40 @@
+import pytest
+from fastapi.testclient import TestClient
+
+from ragdeck.main import app
+
+
+@pytest.fixture()
+def client():
+    return TestClient(app)
+
+
+class TestUIPages:
+    """Regression tests for UI page endpoints.
+
+    These tests verify that Jinja2 TemplateResponse is called with the correct
+    signature (request, name, context) rather than the buggy (name, context).
+    See: https://github.com/aclater/ragdeck/issues/22
+    """
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "/",
+            "/collections-ui",
+            "/querylog-ui",
+            "/ingest-ui",
+            "/metrics-ui",
+            "/admin-ui",
+        ],
+    )
+    def test_ui_pages_return_200_with_html(self, client, path):
+        response = client.get(path)
+        assert response.status_code == 200, f"{path} returned {response.status_code}"
+        assert response.headers["content-type"].startswith("text/html")
+        assert response.text.startswith("<!DOCTYPE html>")
+
+    def test_dashboard_has_nav(self, client):
+        response = client.get("/")
+        assert response.status_code == 200
+        assert "ragdeck" in response.text.lower()


### PR DESCRIPTION
Closes #22

## Problem
All 6 UI page endpoints (`/`, `/collections-ui`, `/querylog-ui`, `/ingest-ui`, `/metrics-ui`, `/admin-ui`) returned 500 with `TypeError: unhashable type: 'dict'` on every request.

## Root Cause
Starlette 1.0.0 `Jinja2Templates.TemplateResponse` expects signature `(request, name, context)`, but all 6 UI endpoints called it with `(Name, context)`:

```python
# BUGGY — passes str as request, dict as name
return templates.TemplateResponse("dashboard.html", {"request": request})
```

This caused Jinja2's cache to receive a dict as cache key → `TypeError: unhashable type: 'dict'`.

## Solution
Correct all 6 calls to `(request, name, context)` order.

## Testing
- 34 tests passing (27 existing + 7 new regression tests)
- ruff: no issues
- CodeRabbit: no CRITICAL/HIGH findings

## Live Verification
```bash
curl -s -4 http://localhost:8092/ | head -5
# Returns <!DOCTYPE html> (200) instead of 500
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated FastAPI template rendering for dashboard UI routes.

* **Tests**
  * Added comprehensive test coverage for all dashboard UI pages, verifying proper HTTP responses, content types, and page content. This new test suite covers the home page and specialized UI sections for collections, query logs, data ingest, system metrics, and administration areas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->