### PR TITLE
feat(ragdeck): restructure README and create docs/ with full API reference (fixes #36)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,15 @@ Admin UI for the rag-suite stack. Single-pane management for all services — co
 
 ## What it does
 
-ragdeck is the administrative control plane for the rag-suite. It provides a unified interface to:
+ragdeck is the administrative control plane for the rag-suite:
 
-- **Collections** — browse Qdrant collections across all routes, view collection stats
-- **Ingest** — monitor ragstuffer job status, view processing queues
+- **Collections** — browse Qdrant collections, view vector counts, create and delete
+- **Ingest** — monitor ragstuffer job status, trigger incremental or full ingest
 - **Query log** — search and filter the ragpipe query log, inspect grounding decisions and citations
-- **Metrics** — real-time dashboards powered by ragwatch (Prometheus + Grafana)
+- **Metrics** — real-time structured dashboards powered by ragwatch (Prometheus)
+- **Admin** — view and hot-reload ragpipe routing and system prompt
 
-## How it fits into rag-suite
+## Architecture
 
 ```
 ┌─────────────────────────────────────────────┐
@@ -23,28 +24,16 @@ ragdeck is the administrative control plane for the rag-suite. It provides a uni
         │          │          │         │
    ┌────▼────┐ ┌───▼────┐ ┌──▼────┐ ┌──▼──────┐
    │ Qdrant  │ │ragstuff│ │ragpipe│ │ragwatch │
-   │         │ │  er    │ │       │ │(Prometheus)│
+   │         │ │  er    │ │       │ │         │
    └─────────┘ └────────┘ └───────┘ └─────────┘
-                                     │
-                                ┌────▼────┐
-                                │ Grafana │
-                                └─────────┘
 ```
 
 ## Quick start (container)
 
 ```bash
-# Pull the published image
-podman pull ghcr.io/aclater/ragdeck:main
-
-# Run with admin token
 podman run --rm -p 8092:8092 \
     -e RAGDECK_ADMIN_TOKEN=your-secure-token \
-    -e RAGPIPE_URL=http://localhost:8090 \
-    -e RAGPIPE_ADMIN_TOKEN=ragpipe-admin-token \
-    -e RAGSTUFFER_URL=http://localhost:8091 \
-    -e RAGSTUFFER_MPEP_URL=http://localhost:8093 \
-    -e QDRANT_URL=http://localhost:6333 \
+    -e DOCSTORE_URL=postgresql://user:pass@host:5432/ragdeck \
     ghcr.io/aclater/ragdeck:main
 ```
 
@@ -55,86 +44,21 @@ pip install git+https://github.com/aclater/ragdeck
 ragdeck
 ```
 
-Or:
+## Documentation
 
-```bash
-git clone https://github.com/aclater/ragdeck
-cd ragdeck
-pip install '.[dev]'
-python -m pytest tests/ -v
-```
-
-## Backend API
-
-All endpoints require `RAGDECK_ADMIN_TOKEN` bearer authentication unless noted.
-
-| Method | Path | Auth | Description |
-|--------|------|------|-------------|
-| `GET` | `/health` | No | Returns `{"status": "ok"}` |
-| `GET` | `/admin/config` | Yes | Returns ragpipe routing and prompt configuration |
-| `GET` | `/collections` | Yes | List all Qdrant collections with stats |
-| `GET` | `/collections/{name}` | Yes | Get specific collection details |
-| `GET` | `/ingest/status` | Yes | ragstuffer ingest job status |
-| `GET` | `/querylog` | Yes | Search ragpipe query log |
-| `GET` | `/querylog/{query_hash}` | Yes | Get specific query log entry |
-| `GET` | `/metrics` | Yes | Prometheus metrics from ragwatch |
-
-## Frontend pages
-
-| Route | Description |
-|-------|-------------|
-| `/` | Dashboard overview |
-| `/collections` | Qdrant collection browser |
-| `/ingest` | Ingest job monitor |
-| `/querylog` | Query log viewer with search |
-| `/metrics` | Real-time metrics dashboard |
-
-## Configuration
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `PORT` | `8092` | Port to listen on |
-| `RAGDECK_ADMIN_TOKEN` | *(required)* | Bearer token for admin authentication |
-| `RAGPIPE_URL` | `http://localhost:8090` | ragpipe API URL |
-| `RAGPIPE_ADMIN_TOKEN` | *(required)* | Token for ragpipe admin endpoints |
-| `RAGSTUFFER_URL` | `http://localhost:8091` | ragstuffer API URL |
-| `RAGSTUFFER_MPEP_URL` | `http://localhost:8093` | ragstuffer-mpep API URL |
-| `QDRANT_URL` | `http://localhost:6333` | Qdrant API URL |
+| Doc | Description |
+|-----|-------------|
+| [docs/api.md](docs/api.md) | Full API endpoint reference with curl examples |
+| [docs/pages.md](docs/pages.md) | Frontend page guide (dashboard, collections, ingest, query log, metrics, admin) |
+| [docs/configuration.md](docs/configuration.md) | All environment variables with defaults |
+| [docs/agentic.md](docs/agentic.md) | Agentic observability: CRAG metrics, Self-RAG, complexity classification |
 
 ## Running tests
 
 ```bash
 pip install '.[dev]'
-python -m pytest tests/ -v    # 24 tests
+python -m pytest tests/ -v    # 53 tests
 ruff check && ruff format --check
-```
-
-## Project structure
-
-```
-ragdeck/
-  __init__.py      — empty (package marker)
-  main.py          — FastAPI app with all endpoints and page routes
-  static/
-    app.js         — frontend JavaScript
-    style.css      — frontend styles
-  templates/
-    base.html      — base template
-    admin.html     — admin config page
-    collections.html — collection browser
-    dashboard.html — overview dashboard
-    ingest.html    — ingest monitor
-    metrics.html   — metrics dashboard
-    querylog.html  — query log viewer
-tests/
-  test_auth.py     — authentication tests
-  test_collections.py — collection endpoint tests
-  test_health.py   — health endpoint tests
-  test_metrics.py  — metrics endpoint tests
-  test_querylog.py — query log endpoint tests
-  test_service_unavailable.py — error handling tests
-quadlets/
-  ragdeck.container — Podman quadlet for systemd integration
 ```
 
 ## License

--- a/docs/agentic.md
+++ b/docs/agentic.md
@@ -1,0 +1,88 @@
+# Agentic Observability
+
+ragdeck surfaces ragorchestrator agentic query behavior through two API endpoints and the query log's agentic columns.
+
+## Requirements
+
+Agentic observability requires:
+- **ragorchestrator** deployed and healthy (`GET /health` returns 200)
+- **query_log table** in Postgres with `query_rewritten` and `retrieval_attempts` columns
+- These columns are populated by ragorchestrator on every agentic query
+
+When these are not available, `/agentic/stats` returns `{"status": "unavailable", "error": "Agentic columns not available in query_log schema"}`.
+
+## Endpoints
+
+### `GET /agentic/stats`
+
+Aggregate agentic metrics across all queries.
+
+```bash
+curl -H "Authorization: Bearer $RAGDECK_ADMIN_TOKEN" \
+  http://localhost:8092/agentic/stats
+```
+
+Response fields:
+- `total_queries` — total queries in the query log
+- `crag_retries` — count of queries where `query_rewritten = TRUE` (query was rewritten by CRAG)
+- `crag_retry_rate` — `crag_retries / total_queries` (proportion of queries requiring rewrite)
+- `avg_retrieval_attempts` — average number of retrieval passes per query
+- `ragorchestrator_up` — whether ragorchestrator is reachable
+- `complexity_distribution` — placeholder: always `{"simple": 0, "complex": 0, "external": 0}` (not yet implemented in ragorchestrator)
+
+### `GET /agentic/traces/{query_hash}`
+
+Full agentic trace for a single query.
+
+```bash
+curl -H "Authorization: Bearer $RAGDECK_ADMIN_TOKEN" \
+  http://localhost:8092/agentic/traces/a1b2c3d4...
+```
+
+Response includes:
+- `query_hash`, `grounding`, `latency_ms`, `created_at`
+- `query_rewritten` — whether CRAG triggered a rewrite
+- `retrieval_attempts` — number of retrieval passes
+- `reflection_result` — `grounded` or `not_applicable`
+- `ragorchestrator_trace` — full trace from ragorchestrator (when available)
+
+## CRAG (Corrective RAG)
+
+CRAG activates when ragorchestrator's Self-RAG reflection loop determines the initial retrieval results are insufficient. When this happens:
+
+1. The query is rewritten with more specific terms
+2. `query_rewritten` is set to `TRUE` in the query log
+3. A new retrieval pass is executed
+4. Final results are grounded and returned
+
+The `crag_retry_rate` metric tracks how often this happens — a high rate may indicate:
+- Chunking strategy needs tuning
+- Collection is missing relevant documents
+- Query complexity exceeds retrieval effectiveness
+
+## Self-RAG Reflection
+
+ragorchestrator uses Self-RAG (Self-Reflective RAG) to evaluate each retrieval pass:
+
+1. **Is the passage relevant?** — Score 0-1 from reflection LLM
+2. **Is the response grounded?** — Did it use the retrieved passages?
+3. **Is the answer useful?** — Would it answer the user's question?
+
+The reflection loop runs up to `MAX_RETRIEVAL_PASSES` (configured in ragorchestrator) until all three criteria are met, or max passes is reached.
+
+## Complexity Classification
+
+ragorchestrator classifies each query into:
+- **simple** — direct lookup, single retrieval pass
+- **complex** — requires multi-hop reasoning or multiple retrieval passes
+- **external** — requires web search (when Tavily is configured)
+
+Complexity classification metrics are tracked in ragorchestrator Prometheus metrics.
+
+## Integration with Dashboard
+
+The query log UI (`/querylog-ui`) shows `query_rewritten` and `retrieval_attempts` columns when agentic columns are present in the Postgres schema. These are displayed as colored badges and numeric values respectively.
+
+## Linking to ragorchestrator
+
+ragdeck proxies trace requests to ragorchestrator at `GET /traces/{query_hash}`. If ragorchestrator returns a trace, it is embedded in the `ragorchestrator_trace` field of the trace response.

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,313 @@
+# API Reference
+
+All endpoints require `RAGDECK_ADMIN_TOKEN` bearer authentication unless noted.
+
+## Health & Status
+
+### `GET /health`
+
+No auth required. Returns service health.
+
+```bash
+curl http://localhost:8092/health
+```
+```json
+{"status": "ok"}
+```
+
+### `GET /status`
+
+Returns status of all rag-suite services.
+
+```bash
+curl -H "Authorization: Bearer $RAGDECK_ADMIN_TOKEN" \
+  http://localhost:8092/status
+```
+```json
+{
+  "status": "ok",
+  "services": {
+    "ragpipe": {"status": "up", "url": "http://localhost:8090"},
+    "ragstuffer": {"status": "up", "url": "http://localhost:8091"},
+    "ragwatch": {"status": "up", "url": "http://localhost:9090"},
+    "ragorchestrator": {"status": "up", "url": "http://localhost:8095"},
+    "qdrant": {"status": "up", "url": "http://localhost:6333"},
+    "postgres": {"status": "up"}
+  }
+}
+```
+
+## Collections
+
+### `GET /collections`
+
+List all Qdrant collections with stats.
+
+```bash
+curl -H "Authorization: Bearer $RAGDECK_ADMIN_TOKEN" \
+  http://localhost:8092/collections
+```
+```json
+{
+  "collections": [
+    {
+      "id": "uuid",
+      "name": "personnel",
+      "description": "...",
+      "source_types": "[\"drive\",\"git\"]",
+      "created_at": "2025-01-15T10:30:00",
+      "vector_count": 14250
+    }
+  ]
+}
+```
+
+### `GET /collections/{name}`
+
+Get specific collection details including Qdrant point counts.
+
+```bash
+curl -H "Authorization: Bearer $RAGDECK_ADMIN_TOKEN" \
+  http://localhost:8092/collections/personnel
+```
+
+### `POST /collections`
+
+Create a new collection. Creates entry in both Postgres and Qdrant.
+
+```bash
+curl -X POST -H "Authorization: Bearer $RAGDECK_ADMIN_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "mypep", "description": "MPEP patent manual"}' \
+  http://localhost:8092/collections
+```
+
+### `DELETE /collections/{name}`
+
+Delete a collection from both Postgres and Qdrant.
+
+```bash
+curl -X DELETE -H "Authorization: Bearer $RAGDECK_ADMIN_TOKEN" \
+  http://localhost:8092/collections/personnel
+```
+
+## Ingest
+
+### `GET /ingest/status`
+
+Ragstuffer ingest job status and collection last-updated times.
+
+```bash
+curl -H "Authorization: Bearer $RAGDECK_ADMIN_TOKEN" \
+  http://localhost:8092/ingest/status
+```
+```json
+{
+  "ragstuffer_up": true,
+  "collections": [
+    {"name": "personnel", "source_types": "[\"drive\"]", "last_updated": "2025-01-20T14:00:00"}
+  ]
+}
+```
+
+### `POST /ingest/trigger`
+
+Trigger incremental ragstuffer ingest (Drive delta, git diff).
+
+```bash
+curl -X POST -H "Authorization: Bearer $RAGDECK_ADMIN_TOKEN" \
+  http://localhost:8092/ingest/trigger
+```
+
+### `POST /ingest/trigger-full`
+
+Trigger full ragstuffer ingest (complete Drive scan, full git clone).
+
+```bash
+curl -X POST -H "Authorization: Bearer $RAGDECK_ADMIN_TOKEN" \
+  http://localhost:8092/ingest/trigger-full
+```
+
+### `GET /ingest/history`
+
+Recent ingest history per collection.
+
+```bash
+curl -H "Authorization: Bearer $RAGDECK_ADMIN_TOKEN" \
+  "http://localhost:8092/ingest/history?limit=10"
+```
+
+## Query Log
+
+### `GET /querylog`
+
+Search and paginate the ragpipe query log.
+
+```bash
+curl -H "Authorization: Bearer $RAGDECK_ADMIN_TOKEN" \
+  "http://localhost:8092/querylog?limit=20&offset=0&grounding=corpus"
+```
+
+Query parameters:
+- `limit` (default 20, max 100)
+- `offset` (default 0)
+- `grounding` (optional: `corpus`, `general`, `mixed`)
+
+### `GET /querylog/stats`
+
+Query log statistics grouped by grounding type.
+
+```bash
+curl -H "Authorization: Bearer $RAGDECK_ADMIN_TOKEN" \
+  http://localhost:8092/querylog/stats
+```
+```json
+{
+  "total": 142,
+  "by_grounding": {
+    "corpus": {"count": 89, "avg_latency": 234.5},
+    "general": {"count": 41, "avg_latency": 156.2},
+    "mixed": {"count": 12, "avg_latency": 412.8}
+  }
+}
+```
+
+### `GET /querylog/{query_hash}`
+
+Get a specific query log entry by hash.
+
+```bash
+curl -H "Authorization: Bearer $RAGDECK_ADMIN_TOKEN" \
+  http://localhost:8092/querylog/a1b2c3d4...
+```
+
+## Agentic Observability
+
+### `GET /agentic/stats`
+
+Agentic query behavior metrics from ragorchestrator. Requires `query_rewritten` and `retrieval_attempts` columns in query_log.
+
+```bash
+curl -H "Authorization: Bearer $RAGDECK_ADMIN_TOKEN" \
+  http://localhost:8092/agentic/stats
+```
+```json
+{
+  "total_queries": 142,
+  "crag_retries": 23,
+  "crag_retry_rate": 0.162,
+  "avg_retrieval_attempts": 1.3,
+  "ragorchestrator_up": true,
+  "complexity_distribution": {"simple": 0, "complex": 0, "external": 0}
+}
+```
+
+Returns `{"status": "unavailable", "error": "Agentic columns not available..."}` when ragorchestrator is not deployed.
+
+### `GET /agentic/traces/{query_hash}`
+
+Full agentic trace for a single query including ragorchestrator reflection data.
+
+```bash
+curl -H "Authorization: Bearer $RAGDECK_ADMIN_TOKEN" \
+  http://localhost:8092/agentic/traces/a1b2c3d4...
+```
+
+## Metrics
+
+### `GET /metrics`
+
+Proxy to ragwatch `/metrics/summary` — structured Prometheus metrics summary.
+
+```bash
+curl -H "Authorization: Bearer $RAGDECK_ADMIN_TOKEN" \
+  http://localhost:8092/metrics
+```
+```json
+{
+  "status": "up",
+  "sources": {
+    "ragpipe": {"up": true, "metric_count": 27},
+    "ragstuffer": {"up": true, "metric_count": 4},
+    "ragorchestrator": {"up": true, "metric_count": 38}
+  },
+  "ragpipe": {"queries_total": 142.0, "embed_cache_hit_rate": 0.87, ...},
+  "ragstuffer": {"documents_ingested_total": 342.0, ...},
+  "ragorchestrator": {"queries_total": 89.0, ...}
+}
+```
+
+### `GET /metrics/ragpipe`
+
+Raw Prometheus metrics text from ragpipe.
+
+```bash
+curl -H "Authorization: Bearer $RAGDECK_ADMIN_TOKEN" \
+  http://localhost:8092/metrics/ragpipe
+```
+
+### `GET /metrics/ragstuffer`
+
+Raw Prometheus metrics text from ragstuffer.
+
+```bash
+curl -H "Authorization: Bearer $RAGDECK_ADMIN_TOKEN" \
+  http://localhost:8092/metrics/ragstuffer
+```
+
+### `GET /metrics/ragorchestrator`
+
+Raw Prometheus metrics text from ragorchestrator.
+
+```bash
+curl -H "Authorization: Bearer $RAGDECK_ADMIN_TOKEN" \
+  http://localhost:8092/metrics/ragorchestrator
+```
+
+## Admin
+
+### `GET /admin/config`
+
+Get ragpipe routing and prompt configuration.
+
+```bash
+curl -H "Authorization: Bearer $RAGDECK_ADMIN_TOKEN" \
+  http://localhost:8092/admin/config
+```
+
+### `POST /admin/reload-routes`
+
+Hot-reload ragpipe routing rules without restart.
+
+```bash
+curl -X POST \
+  -H "Authorization: Bearer $RAGDECK_ADMIN_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"ragpipe_admin_token": "..."}' \
+  http://localhost:8092/admin/reload-routes
+```
+
+### `POST /admin/reload-prompt`
+
+Hot-reload ragpipe system prompt without restart.
+
+```bash
+curl -X POST \
+  -H "Authorization: Bearer $RAGDECK_ADMIN_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"ragpipe_admin_token": "..."}' \
+  http://localhost:8092/admin/reload-prompt
+```
+
+## UI Page Routes
+
+UI pages are rendered as HTML (no auth on the HTML itself; API calls within the page require auth).
+
+| Route | Description |
+|-------|-------------|
+| `GET /` | Dashboard overview |
+| `GET /collections-ui` | Qdrant collection browser |
+| `GET /ingest-ui` | Ingest job monitor |
+| `GET /querylog-ui` | Query log viewer |
+| `GET /metrics-ui` | Real-time metrics dashboard |
+| `GET /admin-ui` | ragpipe admin config |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,74 @@
+# Configuration
+
+All configuration is via environment variables. ragdeck does not use a config file.
+
+## Required
+
+| Variable | Description |
+|----------|-------------|
+| `RAGDECK_ADMIN_TOKEN` | Bearer token for all ragdeck admin API calls. Set to a long random string. |
+
+## Service URLs
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `RAGPIPE_URL` | `http://host.containers.internal:8090` | ragpipe API URL |
+| `RAGSTUFFER_URL` | `http://host.containers.internal:8091` | ragstuffer API URL |
+| `RAGSTUFFER_MPEP_URL` | `http://host.containers.internal:8093` | ragstuffer-mpep API URL (MPEP-only ingest service) |
+| `RAGWATCH_URL` | `http://host.containers.internal:9090` | ragwatch Prometheus aggregator URL |
+| `RAGORCHESTRATOR_URL` | `http://host.containers.internal:8095` | ragorchestrator LangGraph agent URL |
+| `QDRANT_URL` | `http://host.containers.internal:6333` | Qdrant vector database URL |
+| `DOCSTORE_URL` | *(required)* | Postgres connection string, e.g. `postgresql://user:pass@localhost:5432/ragdeck` |
+
+## Service Tokens
+
+| Variable | Description |
+|----------|-------------|
+| `RAGPIPE_ADMIN_TOKEN` | Token for ragpipe admin endpoints (reload-routes, reload-prompt, admin/config). Passed through in admin UI actions. |
+| `RAGSTUFFER_ADMIN_TOKEN` | Token for ragstuffer admin endpoints (ingest trigger). Passed through in ingest UI actions. |
+
+## Container Runtime
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PORT` | `8092` | TCP port ragdeck listens on |
+
+## Hardware-Specific
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `QDRANT__SERVICE__HOST` | `::` | Set to `::` (IPv6 all-interfaces) or `0.0.0.0` for IPv4. Qdrant requires this for IPv4 on some setups. |
+
+## Example: Podman quadlet
+
+```bash
+podman run --rm -p 8092:8092 \
+  --env RAGDECK_ADMIN_TOKEN=your-secure-token \
+  --env DOCSTORE_URL=postgresql://postgres@host.containers.internal:5432/ragdeck \
+  --env RAGPIPE_URL=http://host.containers.internal:8090 \
+  --env RAGPIPE_ADMIN_TOKEN=ragpipe-token \
+  --env RAGSTUFFER_URL=http://host.containers.internal:8091 \
+  --env RAGSTUFFER_ADMIN_TOKEN=ragstuffer-token \
+  --env RAGWATCH_URL=http://host.containers.internal:9090 \
+  --env RAGORCHESTRATOR_URL=http://host.containers.internal:8095 \
+  --env QDRANT_URL=http://host.containers.internal:6333 \
+  ghcr.io/aclater/ragdeck:main
+```
+
+## Example: docker-compose fragment
+
+```yaml
+ragdeck:
+  image: ghcr.io/aclater/ragdeck:main
+  ports:
+    - "8092:8092"
+  env_file: ragstack.env
+  environment:
+    RAGDECK_ADMIN_TOKEN: "${RAGDECK_ADMIN_TOKEN}"
+    DOCSTORE_URL: "postgresql://postgres@host.containers.internal:5432/ragdeck"
+    RAGPIPE_URL: "http://ragpipe:8090"
+    RAGSTUFFER_URL: "http://ragstuffer:8091"
+    RAGWATCH_URL: "http://ragwatch:9090"
+    RAGORCHESTRATOR_URL: "http://ragorchestrator:8095"
+    QDRANT_URL: "http://qdrant:6333"
+```

--- a/docs/pages.md
+++ b/docs/pages.md
@@ -1,0 +1,86 @@
+# UI Pages
+
+ragdeck provides six frontend pages, all accessible at `/<name>-ui` (e.g. `/collections-ui`).
+
+## Dashboard (`/`)
+
+Overview of the entire rag-suite stack.
+
+**Service health tiles** — one per service (ragpipe, ragstuffer, ragorchestrator, ragwatch, Qdrant, Postgres) showing live up/down status. Refreshes every 30 seconds.
+
+**Summary tiles** — total collections, queries today, corpus grounding rate, average latency.
+
+**Grounding distribution** — donut chart showing proportion of corpus/general/mixed queries from the query log.
+
+**Recent queries table** — last 10 queries with time, grounding badge, latency, and cited chunk count. Click any row to inspect the full query entry.
+
+## Collections (`/collections-ui`)
+
+Browse all Qdrant collections registered in Postgres.
+
+**Collection list** — table with name, vector count, source types, and created date.
+
+**Actions per row:**
+- **View** — opens a detail panel showing collection ID, description, Qdrant vector/point counts, source types, and created timestamp.
+- **Delete** — removes the collection from both Postgres and Qdrant (with confirmation dialog).
+
+**Create collection** — form at the top to register a new collection. Creates entry in Postgres and Qdrant simultaneously.
+
+## Ingest (`/ingest-ui`)
+
+Monitor ragstuffer ingest jobs and collection freshness.
+
+**Ragstuffer status** — up/down badge for ragstuffer service.
+
+**Collection table** — each registered collection with source types and last-updated timestamp.
+
+**Trigger buttons:**
+- **Ingest Now** — triggers incremental ingest (Drive delta, git diff only)
+- **Ingest Full** — triggers full re-ingest (complete Drive scan, full git clone)
+
+Requires `RAGSTUFFER_ADMIN_TOKEN` configured in the environment.
+
+## Query Log (`/querylog-ui`)
+
+Searchable, paginated view of all ragpipe queries.
+
+**Filter bar** — filter by grounding type (corpus, general, mixed) or view all.
+
+**Query table** — columns: Time, Grounding (colored badge), Latency, Cited chunks, Hash (truncated).
+
+**Click any row** — opens an expandable detail panel showing:
+- Full query hash
+- Grounding type badge
+- Latency in milliseconds
+- Timestamp
+- List of cited chunks as JSON
+
+**Pagination** — 20 entries per page with prev/next navigation.
+
+## Metrics (`/metrics-ui`)
+
+Real-time Prometheus metrics from ragwatch, rendered as structured cards.
+
+**Service health tiles** — ragpipe, ragstuffer, ragorchestrator with up/down status and metric count.
+
+**ragpipe metrics** — Queries, Cache Hits, Cache Misses, Cache Hit Rate, Invalid Citations, Chunks Retrieved.
+
+**ragstuffer metrics** — Documents Ingested, Chunks Created, Embed Requests, Embed Errors.
+
+**ragorchestrator metrics** — Queries, Avg Latency, Tool Calls, Complexity Classifications.
+
+**Raw JSON toggle** — collapsed by default; click Show/Hide to inspect the full ragwatch response for debugging.
+
+Auto-refreshes every 60 seconds. Gracefully shows an error message if ragwatch is unavailable.
+
+## Admin (`/admin-ui`)
+
+ragpipe routing and prompt configuration viewer.
+
+**Current config** — displays the live ragpipe `/admin/config` response as JSON.
+
+**Actions:**
+- **Reload Routes** — hot-reloads ragpipe routing rules via `POST /admin/reload-routes`
+- **Reload Prompt** — hot-reloads the system prompt via `POST /admin/reload-prompt`
+
+Both actions require `RAGPIPE_ADMIN_TOKEN`. Results shown inline without page refresh.


### PR DESCRIPTION
Closes #36

## Problem
README.md was 142 lines with endpoint tables, configuration, and testing all inline. No docs/ directory existed. As the admin UI, ragdeck needed clear documentation of all pages, API endpoints, and agentic observability features.

## Solution
- **Slimmed README to 66 lines** — description, architecture SVG, quick start (container + pip), linked TOC table
- **Created docs/api.md** (313 lines) — full endpoint reference for all 20+ endpoints with curl examples and JSON responses
- **Created docs/pages.md** (86 lines) — frontend page guide describing all 6 UI pages and their features
- **Created docs/configuration.md** (74 lines) — all 12+ environment variables with defaults, descriptions, and Podman/docker-compose examples
- **Created docs/agentic.md** (88 lines) — agentic observability: CRAG metrics, Self-RAG reflection, complexity classification, ragorchestrator integration

## Testing
53 tests pass, ruff lint clean.

## Implementation notes
- All 4 docs pages linked from README TOC table
- README test count updated to reflect 53 (was 24)