### PR TITLE
Wire complexity_distribution from ragorchestrator metrics (fixes #29)

### DIFF
--- a/ragdeck/main.py
+++ b/ragdeck/main.py
@@ -588,6 +588,50 @@ async def get_querylog_entry(query_hash: str):
 # ── Agentic Observability ───────────────────────────────────────────────────────
 
 
+def _parse_prometheus_counter(text: str, metric_name: str, label: str) -> dict[str, float]:
+    """Parse a Prometheus counter with labels into a dict of {label_value: count}.
+
+    Example input:
+        ragorchestrator_complexity_classified_total{complexity="simple"} 5.0
+        ragorchestrator_complexity_classified_total{complexity="complex"} 2.0
+
+    Returns: {"simple": 5.0, "complex": 2.0}
+    """
+    import re
+
+    pattern = re.compile(
+        rf'^{re.escape(metric_name)}\{{{re.escape(label)}="([^"]+)"\}}\s+([\d.eE+-]+)',
+        re.MULTILINE,
+    )
+    return {m.group(1): float(m.group(2)) for m in pattern.finditer(text)}
+
+
+async def _fetch_complexity_distribution() -> dict[str, int]:
+    """Fetch complexity classification counts from ragorchestrator /metrics.
+
+    Falls back to zeros if ragorchestrator is unreachable or metrics
+    are not available.
+    """
+    default = {"simple": 0, "complex": 0, "external": 0}
+    try:
+        async with httpx.AsyncClient(timeout=HTTP_TIMEOUT) as client:
+            resp = await client.get(f"{RAGORCHESTRATOR_URL}/metrics")
+            if resp.status_code != 200:
+                return default
+            counts = _parse_prometheus_counter(
+                resp.text,
+                "ragorchestrator_complexity_classified_total",
+                "complexity",
+            )
+            return {
+                "simple": int(counts.get("simple", 0)),
+                "complex": int(counts.get("complex", 0)),
+                "external": int(counts.get("external", 0)),
+            }
+    except Exception:
+        return default
+
+
 @app.get("/agentic/stats")
 async def get_agentic_stats():
     """Dashboard showing agentic query behavior metrics.
@@ -631,7 +675,7 @@ async def get_agentic_stats():
             except Exception:
                 stats["ragorchestrator_up"] = False
 
-            stats["complexity_distribution"] = {"simple": 0, "complex": 0, "external": 0}
+            stats["complexity_distribution"] = await _fetch_complexity_distribution()
 
             return stats
     except Exception as e:

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from fastapi.testclient import TestClient
 
-from ragdeck.main import app
+from ragdeck.main import _parse_prometheus_counter, app
 
 
 @pytest.fixture
@@ -96,3 +96,24 @@ class TestMetricsRagorchestrator:
             assert response.status_code == 200
             data = response.json()
             assert "metrics" in data
+
+
+class TestParsePrometheusCounter:
+    def test_parses_labeled_counter(self):
+        text = (
+            "# HELP ragorchestrator_complexity_classified_total Total\n"
+            "# TYPE ragorchestrator_complexity_classified_total counter\n"
+            'ragorchestrator_complexity_classified_total{complexity="simple"} 5.0\n'
+            'ragorchestrator_complexity_classified_total{complexity="complex"} 2.0\n'
+        )
+        result = _parse_prometheus_counter(text, "ragorchestrator_complexity_classified_total", "complexity")
+        assert result == {"simple": 5.0, "complex": 2.0}
+
+    def test_returns_empty_for_no_match(self):
+        result = _parse_prometheus_counter("some_other_metric 42\n", "missing_metric", "label")
+        assert result == {}
+
+    def test_handles_scientific_notation(self):
+        text = 'my_counter{label="val"} 1.5e+03\n'
+        result = _parse_prometheus_counter(text, "my_counter", "label")
+        assert result == {"val": 1500.0}


### PR DESCRIPTION
Closes #29

## Problem
`/agentic/stats` returns `complexity_distribution` hardcoded to `{"simple": 0, "complex": 0, "external": 0}`.

## Solution
Fetch `ragorchestrator_complexity_classified_total` from `/metrics` endpoint, parse the Prometheus counter by complexity label, and return real counts. Falls back to zeros gracefully if ragorchestrator is unreachable.

## Testing
- 37 tests passing (3 new: Prometheus counter parser tests)
- Ruff clean

## Verification
```bash
curl -s http://localhost:8092/agentic/stats | python3 -c "
import sys, json
d = json.load(sys.stdin)
print('complexity_distribution:', d.get('complexity_distribution'))
"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `/agentic/stats` endpoint now dynamically retrieves complexity distribution metrics (simple, complex, external) from your metrics system instead of static values, with graceful fallback to zero defaults if unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->